### PR TITLE
fix #37 - exception handler of ConsoleScanner

### DIFF
--- a/src/main/java/util/ConsoleScanner.java
+++ b/src/main/java/util/ConsoleScanner.java
@@ -91,10 +91,11 @@ public class ConsoleScanner {
                     RequestMapping requestMapping = mt.getDeclaredAnnotation(RequestMapping.class);
                     if (requestMapping != null && requestMapping.uri().equals(uri)) {
                         Object instance = cls.getDeclaredConstructor().newInstance();
-                        if (queryString != null)
-                            mt.invoke(instance, queryString);
-                        else
+                        try {
                             mt.invoke(instance);
+                        } catch (IllegalArgumentException e) {
+                            mt.invoke(instance, queryString);
+                        }
                         return;
                     }
                 }


### PR DESCRIPTION
이상 입력에 대한 예외처리가 되지 않아서 이전 코드로 다시 복귀합니다.
이상 입력 예시) 선수목록